### PR TITLE
regex matcher

### DIFF
--- a/regex.cpp
+++ b/regex.cpp
@@ -1,0 +1,214 @@
+#include "regex.h"
+#include <iostream>
+#include <cassert>
+namespace regex {
+
+Node::Node() : node_index_(-1), is_accepting_(false), visited_(false) {}
+
+Node::Node(int index)
+    : node_index_(index), is_accepting_(false), visited_(false) {}
+
+void Node::AddEdge(int to, char symbol) {
+  edges_[symbol].push_back(to);
+}
+
+void Node::AddEpsilonEdge(int to) {
+  epsilon_edges_.push_back(to);
+}
+
+RegexMatcher::RegexMatcher(std::string infix_regex)
+    : postfix_regex_(InfixToPostfix(infix_regex)) {
+  for (char c : postfix_regex_) {
+    if (c == '|') {
+      AddUnion();
+    } else if (c == '.') {
+      AddConcatenation();
+    } else if (c == '*') {
+      AddKleeneStar();
+    } else {
+      AddSymbol(c);
+    }
+  }
+  std::tie(start_state_, accept_state_) = build_stack_.top();
+  build_stack_.pop();
+  assert(build_stack_.empty());
+}
+
+std::tuple<Node, Node> RegexMatcher::GetStartEndNodes() {
+  int num_states = static_cast<int>(states_.size());
+  return std::make_tuple(Node(num_states), Node(num_states + 1));
+}
+
+// NFA for a single symbol.
+// creates two states and makes the transition
+// between them to have the given symbol.
+void RegexMatcher::AddSymbol(char symbol) {
+  Node start_state, end_state;
+  std::tie(start_state, end_state) = GetStartEndNodes();
+  start_state.AddEdge(end_state.node_index_, symbol);
+  states_.push_back(start_state); 
+  states_.push_back(end_state);
+  build_stack_.push(
+      std::make_tuple(start_state.node_index_, end_state.node_index_));
+}
+
+// Creates an NFA with the union of
+// the two NFAs in the top of the stack.
+// Pushes the new start and end states to the stack.
+void RegexMatcher::AddUnion() {
+  int start_a, end_a, start_b, end_b;
+  std::tie(start_b, end_b) = build_stack_.top();
+  build_stack_.pop();
+  std::tie(start_a, end_a) = build_stack_.top();
+  build_stack_.pop();
+
+  Node start_state, end_state;
+  std::tie(start_state, end_state) = GetStartEndNodes();
+
+  start_state.AddEpsilonEdge(start_a);
+  start_state.AddEpsilonEdge(start_b);
+  states_[end_a].AddEpsilonEdge(end_state.node_index_);
+  states_[end_b].AddEpsilonEdge(end_state.node_index_);
+
+  states_.push_back(start_state);
+  states_.push_back(end_state);
+  build_stack_.push(
+      std::make_tuple(start_state.node_index_, end_state.node_index_));
+}
+
+// Creates an NFA with the concatenation of the
+// two NFAs in the top of the stack.
+// Pushes the new start and end indexes to the stack.
+void RegexMatcher::AddConcatenation() {
+  int start_a, end_a, start_b, end_b;
+  std::tie(start_b, end_b) = build_stack_.top();
+  build_stack_.pop();
+  std::tie(start_a, end_a) = build_stack_.top();
+  build_stack_.pop();
+
+  states_[end_a].AddEpsilonEdge(start_b);
+  build_stack_.push(std::make_tuple(start_a, end_b));
+}
+
+// Creates an NFA for the Kleene star of the last
+// NFA in the stack.
+// Pushes the new start and end indexes to the stack.
+void RegexMatcher::AddKleeneStar() {
+  int start_a, end_a;
+  std::tie(start_a, end_a) = build_stack_.top();
+  build_stack_.pop();
+
+  Node start_state, end_state;
+  std::tie(start_state, end_state) = GetStartEndNodes();
+
+  start_state.AddEpsilonEdge(start_a);
+  start_state.AddEpsilonEdge(end_state.node_index_);
+  states_[end_a].AddEpsilonEdge(start_a);
+  states_[end_a].AddEpsilonEdge(end_state.node_index_);
+
+  states_.push_back(start_state);
+  states_.push_back(end_state);
+  build_stack_.push(
+      std::make_tuple(start_state.node_index_, end_state.node_index_));
+}
+
+// convert a regular expresion from infix to
+// postfix form using the shunting yard algorithm.
+// e.g. "a.(b|c).d" -> "abc|.d."
+// this assumes all continuous input symbols are joined
+// by the concatenation operator.
+std::string RegexMatcher::InfixToPostfix(std::string &infix_regex) {
+  std::map<char, int> operator_precedence = {
+      {'*', 0}, {'.', 1}, {'|', 2},
+  };
+  std::string postfix;
+  std::stack<char> s;
+  for (char c : infix_regex) {
+    bool is_operator = (operator_precedence.count(c) != 0);
+    if (!is_operator && c != '(' && c != ')') {
+      postfix.push_back(c);
+    } else if (is_operator) {
+      while (!s.empty() && s.top() != '(' &&
+             operator_precedence[s.top()] <= operator_precedence[c]) {
+        postfix.push_back(s.top());
+        s.pop();
+      }
+      s.push(c);
+    } else if (c == '(') {
+      s.push(c);
+    } else {
+      assert(c == ')');
+      while (!s.empty() && s.top() != '(') {
+        postfix.push_back(s.top());
+        s.pop();
+      }
+      assert(!s.empty() && s.top() == '(');
+      s.pop();
+    }
+  }
+  while (!s.empty()) {
+    postfix.push_back(s.top());
+    s.pop();
+  }
+#ifdef DEBUG
+  std::cerr << "infix: " << infix_regex << " " << postfix << std::endl;
+#endif
+  return postfix;
+}
+
+// method to compute the epsilon closure of a given state
+// it recursively visits the states reachable through
+// epsilon transitions and stores the explored nodes in
+// the parameter visited.
+void RegexMatcher::DfsEpsilon(int current_state, std::vector<int> &visited) {
+  visited.push_back(current_state);
+  states_[current_state].visited_ = true;
+  for (int to : states_[current_state].epsilon_edges_) {
+    if (!states_[to].visited_) {
+      DfsEpsilon(to, visited);
+    }
+  }
+}
+
+void print_state(std::vector<int> &s) {
+  std::cerr << "current state: ";
+  for (int v : s) std::cerr << v << ", ";
+  std::cerr << std::endl;
+}
+
+// interface to check if the regex accepts an input
+// string. Simulates the NFA using the DfsEpsilon method
+// defined above.
+bool RegexMatcher::Matches(const std::string &input) {
+  for (auto &state : states_) {
+    state.visited_ = false;
+  }
+  std::vector<int> current_state;
+  DfsEpsilon(start_state_, current_state);
+
+
+  for (char c : input) {
+    for (auto &state : states_) {
+      state.visited_ = false;
+    }
+    std::vector<int> next_state;
+    for (int v : current_state) {
+      for (int to : states_[v].edges_[c]) {
+        DfsEpsilon(to, next_state);
+      }
+    }
+    if (next_state.empty()) {
+      return false;
+    }
+    std::swap(current_state, next_state);
+  }
+
+
+  for (int v : current_state) {
+    if (v == accept_state_) {
+      return true;
+    }
+  }
+  return false;
+}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 11)
 
 include_directories(${Compilers_SOURCE_DIR})
 
-set(TEST_SRC ${Compilers_SOURCE_DIR}/regex.h ${Compilers_SOURCE_DIR}/flexer.h ${Compilers_SOURCE_DIR}/flexer.cpp)
+set(TEST_SRC ${Compilers_SOURCE_DIR}/regex.cpp ${Compilers_SOURCE_DIR}/flexer.h ${Compilers_SOURCE_DIR}/flexer.cpp)
 set(TEST_FILES testmain.cpp)
 message(${TEST_SRC})
 add_executable(my_test ${TEST_FILES} ${TEST_SRC})

--- a/test/testmain.cpp
+++ b/test/testmain.cpp
@@ -9,23 +9,84 @@
 
 TEST_CASE("infix to postfix") {
   std::string regex_1 = "a.b|c.d";
-  REQUIRE(regex::InfixToPostfix(regex_1) == "ab.cd.|");
+  REQUIRE(regex::RegexMatcher(regex_1).postfix_regex_ == "ab.cd.|");
   std::string regex_2 = "a.(b|c).d";
-  REQUIRE(regex::InfixToPostfix(regex_2) == "abc|.d.");
+  REQUIRE(regex::RegexMatcher(regex_2).postfix_regex_ == "abc|.d.");
   std::string regex_3 = "a.b.c.d";
-  REQUIRE(regex::InfixToPostfix(regex_3) == "ab.c.d.");
+  REQUIRE(regex::RegexMatcher(regex_3).postfix_regex_  == "ab.c.d.");
   std::string regex_4 = "a";
-  REQUIRE(regex::InfixToPostfix(regex_4) == "a");
+  REQUIRE(regex::RegexMatcher(regex_4).postfix_regex_ == "a");
   std::string regex_5 = "a*";
-  REQUIRE(regex::InfixToPostfix(regex_5) == "a*");
+  REQUIRE(regex::RegexMatcher(regex_5).postfix_regex_ == "a*");
   std::string regex_6 = "a*.b";
-  REQUIRE(regex::InfixToPostfix(regex_6) == "a*b.");
+  REQUIRE(regex::RegexMatcher(regex_6).postfix_regex_ == "a*b.");
   std::string regex_7 = "b.z.a*.d.(a.b)*";
-  REQUIRE(regex::InfixToPostfix(regex_7) == "bz.a*.d.ab.*.");
+  REQUIRE(regex::RegexMatcher(regex_7).postfix_regex_ == "bz.a*.d.ab.*.");
   std::string regex_8 = "(a.b|c*.d)*";
-  REQUIRE(regex::InfixToPostfix(regex_8) == "ab.c*d.|*");
+  REQUIRE(regex::RegexMatcher(regex_8).postfix_regex_ == "ab.c*d.|*");
   std::string regex_9 = "(1|2|3|4)*";
-  REQUIRE(regex::InfixToPostfix(regex_9) == "12|3|4|*");
+  REQUIRE(regex::RegexMatcher(regex_9).postfix_regex_ == "12|3|4|*");
+}
+
+TEST_CASE("regex matching_1") {
+  std::string regex = "(a.b|c*.d)*";
+  regex::RegexMatcher compiled_regex(regex);
+  std::vector<std::string> test_correct({
+      "ab",
+      "",
+      "abd",
+      "abcccccccccccccccd",
+      "abababcccdabd",
+      "abddddddddddddcccccdcdcdcdab",
+      "ccccccccccccdddcdcdcdcddddcccdddccdcddcccdcdcdddd"
+  });
+  for (auto test_string : test_correct) {
+    REQUIRE(compiled_regex.Matches(test_string) == true);
+  }
+
+  std::vector<std::string> test_incorrect({
+    "a",
+    "abababccccccccccccc",
+    "abccccccdddccdda",
+    "c",
+    "ababababababccccdddccdddabz",
+    "12",
+    "abababababbb",
+    "abccccc",
+  });
+
+  for (auto test_string : test_incorrect) {
+    REQUIRE(compiled_regex.Matches(test_string) == false);
+  }
+}
+
+TEST_CASE("regex matching_2") {
+  std::string regex =
+      "(1|2|3|4|5|6|7|8|9).(0|1|2|3|4|5|6|7|8|9)*.,.(0|1|2|3|4|5|6|7|8|9)";
+  regex::RegexMatcher compiled_regex(regex);
+  std::vector<std::string> test_correct({
+      "12334123339990000,1",
+      "121212,9",
+      "1,0",
+      "9,0",
+      "129349404,6",
+  });
+  for (auto test_string : test_correct) {
+    REQUIRE(compiled_regex.Matches(test_string) == true);
+  }
+
+  std::vector<std::string> test_incorrect({
+      "1233412333999102",
+      "1234,12",
+      "0,01212",
+      "121212,6666",
+      "121212,",
+      "0,123",
+      "899",
+  });
+  for (auto test_string : test_incorrect) {
+    REQUIRE(compiled_regex.Matches(test_string) == false);
+  }
 }
 
 


### PR DESCRIPTION
This adds a class that matches regular expressions constructing an NFA and simulating it. 

The basic idea is to transform the regex to "postfix" form which is equivalent to parsing and constructing the syntax tree for it. Once it's on postfix, you can process it left to right keeping a stack with the current NFAs built and when encountering an operator, proceed with the corresponding construction popping the needed operands from the stack (maybe just one in the case of kleene star, for example). To simplify stuff I just maintained a list of states and the stack contains the index of the initial and accepting state.

The simulation is then pretty simple just following the algorithm in the book.

Stuff missing:
- allow . * | as input characters escaping them somehow (right now it will interpret those as the operators).
- allow strings instead of single characters joined by concatenation. this can be done by pre-processing the string and adding some arbitrary character that could be interpreted as concatenation.
- combine all the regex needed as flex does (section 3.8 in the book).
