### PR TITLE
Bug fixed: matching all /* comments */ as one.

### DIFF
--- a/flexer.l
+++ b/flexer.l
@@ -13,7 +13,7 @@ identifier {letter_}({letter_}|{digit})*
 optional_fraction ("."{digits})?
 optional_exponent ("E"("+"|"-")?{digits})?
 number {digits}{optional_fraction}{optional_exponent}
-comment "/*"(.|\n)*"*/"|"//".*\n
+comment "/*"[^*/\/]*"*/"|"//".*\n
 %%
 {ws}+             /* do nothing */
 {comment}         /* do nothing */

--- a/test_comments.decaf
+++ b/test_comments.decaf
@@ -1,0 +1,24 @@
+// File for testing comment recognition
+class Program {
+  /* Global variables */
+  int i, j;
+  real number;
+
+  /* Main function */
+  static void main() {
+    i = 0;
+    j = 1;
+    // If statement
+    if ( i < j ) {
+      number = 12.34;
+    }
+    else {
+      number = 12.34E7
+    }
+    i = i + j;
+  }
+  /*
+  End of
+  main function
+  */
+}


### PR DESCRIPTION
The `[^*/\/]` should be matching everything except "*" followed by "/".