### PR TITLE
preprocess regex to allow continuous characters

### DIFF
--- a/regex.cpp
+++ b/regex.cpp
@@ -1,7 +1,122 @@
 #include "regex.h"
 #include <iostream>
 #include <cassert>
+
 namespace regex {
+
+// we escape the original operators with 
+// non printable characters.
+namespace operators {
+const char STAR = 26;
+const char UNION = 27;
+const char CONCATENATION = 28;
+const char LPAR = 29;
+const char RPAR = 30;
+}
+
+std::map<char, char> operator_to_hidden = {
+  {'*', operators::STAR},
+  {'|', operators::UNION},
+  {'(', operators::LPAR},
+  {')', operators::RPAR}
+};
+
+std::map<char, char> hidden_to_operator = {
+  {operators::STAR, '*'},
+  {operators::UNION, '|'},
+  {operators::LPAR, '('},
+  {operators::RPAR, ')'},
+  {operators::CONCATENATION, '.'}
+};
+
+std::map<char, int> operator_precedence = {
+  {operators::STAR, 0},
+  {operators::CONCATENATION, 1},
+  {operators::UNION, 2}
+};
+
+
+// convert operators to special symbols
+// and add explicit concatenation.
+std::string PreProcessRegex(std::string infix_regex) {
+  std::string fixed;
+  int n = static_cast<int>(infix_regex.size());
+  bool escape = false;
+  for (int i = 0; i < n; i++) {
+    char c = infix_regex[i];
+    if (escape) {
+      fixed.push_back(c);
+      escape = false;
+    } else if (operator_to_hidden.count(c)) {
+      fixed.push_back(operator_to_hidden[c]);
+    } else if (c == '\\') {
+      escape = true;
+      continue;
+    } else {
+      fixed.push_back(c);
+    }
+
+    // add concatenation
+    if (i + 1 < n &&
+        c != '|' &&
+        c != '(' &&
+        infix_regex[i + 1] != '|' &&
+        infix_regex[i + 1] != ')' &&
+        infix_regex[i + 1] != '*') {
+      fixed.push_back(operators::CONCATENATION);
+    }
+  }
+  std::cerr << "after pre-process" << std::endl;
+  for (char c : fixed) std::cerr << (hidden_to_operator.count(c) ? hidden_to_operator[c] : c); 
+  std::cerr << std::endl;
+  return fixed;
+}
+
+// convert a regular expresion from infix to
+// postfix form using the shunting yard algorithm.
+// e.g. "a.(b|c).d" -> "abc|.d."
+// this assumes all continuous input symbols are joined
+// by the concatenation operator.
+std::string InfixToPostfix(std::string &infix_regex) {
+  std::string escaped_infix = regex::PreProcessRegex(infix_regex);
+  std::string postfix;
+  std::stack<char> s;
+  for (char c : escaped_infix) {
+    bool is_operator = (operator_precedence.count(c) != 0);
+    if (!is_operator && c != operators::LPAR && c != operators::RPAR) {
+      postfix.push_back(c);
+    } else if (is_operator) {
+      while (!s.empty() && s.top() != operators::LPAR &&
+             operator_precedence[s.top()] <= operator_precedence[c]) {
+        postfix.push_back(s.top());
+        s.pop();
+      }
+      s.push(c);
+    } else if (c == operators::LPAR) {
+      s.push(c);
+    } else {
+      assert(c == operators::RPAR);
+      while (!s.empty() && s.top() != operators::LPAR) {
+        postfix.push_back(s.top());
+        s.pop();
+      }
+      assert(!s.empty() && s.top() == operators::LPAR);
+      s.pop();
+    }
+  }
+  while (!s.empty()) {
+    postfix.push_back(s.top());
+    s.pop();
+  }
+#ifdef DEBUG
+  std::cerr << "infix: " << infix_regex << " " << postfix << std::endl;
+#endif
+  std::cerr << "after postfix" << std::endl;
+  for (char c : postfix) std::cerr << (hidden_to_operator.count(c) ? hidden_to_operator[c] : c); 
+  std::cerr << std::endl;
+  return postfix;
+}
+
 
 Node::Node() : node_index_(-1), is_accepting_(false), visited_(false) {}
 
@@ -17,13 +132,13 @@ void Node::AddEpsilonEdge(int to) {
 }
 
 RegexMatcher::RegexMatcher(std::string infix_regex)
-    : postfix_regex_(InfixToPostfix(infix_regex)) {
+    : postfix_regex_(regex::InfixToPostfix(infix_regex)) {
   for (char c : postfix_regex_) {
-    if (c == '|') {
+    if (c == operators::UNION) {
       AddUnion();
-    } else if (c == '.') {
+    } else if (c == operators::CONCATENATION) {
       AddConcatenation();
-    } else if (c == '*') {
+    } else if (c == operators::STAR) {
       AddKleeneStar();
     } else {
       AddSymbol(c);
@@ -32,6 +147,13 @@ RegexMatcher::RegexMatcher(std::string infix_regex)
   std::tie(start_state_, accept_state_) = build_stack_.top();
   build_stack_.pop();
   assert(build_stack_.empty());
+}
+
+std::string RegexMatcher::postfix_regex() {
+  std::string out;
+  for (char c : postfix_regex_)
+    out.push_back(hidden_to_operator.count(c) ? hidden_to_operator[c] : c);
+  return out;
 }
 
 std::tuple<Node, Node> RegexMatcher::GetStartEndNodes() {
@@ -112,50 +234,6 @@ void RegexMatcher::AddKleeneStar() {
       std::make_tuple(start_state.node_index_, end_state.node_index_));
 }
 
-// convert a regular expresion from infix to
-// postfix form using the shunting yard algorithm.
-// e.g. "a.(b|c).d" -> "abc|.d."
-// this assumes all continuous input symbols are joined
-// by the concatenation operator.
-std::string RegexMatcher::InfixToPostfix(std::string &infix_regex) {
-  std::map<char, int> operator_precedence = {
-      {'*', 0}, {'.', 1}, {'|', 2},
-  };
-  std::string postfix;
-  std::stack<char> s;
-  for (char c : infix_regex) {
-    bool is_operator = (operator_precedence.count(c) != 0);
-    if (!is_operator && c != '(' && c != ')') {
-      postfix.push_back(c);
-    } else if (is_operator) {
-      while (!s.empty() && s.top() != '(' &&
-             operator_precedence[s.top()] <= operator_precedence[c]) {
-        postfix.push_back(s.top());
-        s.pop();
-      }
-      s.push(c);
-    } else if (c == '(') {
-      s.push(c);
-    } else {
-      assert(c == ')');
-      while (!s.empty() && s.top() != '(') {
-        postfix.push_back(s.top());
-        s.pop();
-      }
-      assert(!s.empty() && s.top() == '(');
-      s.pop();
-    }
-  }
-  while (!s.empty()) {
-    postfix.push_back(s.top());
-    s.pop();
-  }
-#ifdef DEBUG
-  std::cerr << "infix: " << infix_regex << " " << postfix << std::endl;
-#endif
-  return postfix;
-}
-
 // method to compute the epsilon closure of a given state
 // it recursively visits the states reachable through
 // epsilon transitions and stores the explored nodes in
@@ -186,7 +264,6 @@ bool RegexMatcher::Matches(const std::string &input) {
   std::vector<int> current_state;
   DfsEpsilon(start_state_, current_state);
 
-
   for (char c : input) {
     for (auto &state : states_) {
       state.visited_ = false;
@@ -202,7 +279,6 @@ bool RegexMatcher::Matches(const std::string &input) {
     }
     std::swap(current_state, next_state);
   }
-
 
   for (int v : current_state) {
     if (v == accept_state_) {

--- a/regex.h
+++ b/regex.h
@@ -35,14 +35,15 @@ class Node {
 class RegexMatcher {
  public:
   RegexMatcher(std::string infix_regex);
-  std::string postfix_regex_;
 
   bool Matches(const std::string &input);
+  std::string postfix_regex();
 
  private:
   int start_state_, accept_state_;
   std::vector<Node> states_;
   std::stack<std::tuple<int, int>> build_stack_;
+  std::string postfix_regex_;
 
   std::tuple<Node, Node> GetStartEndNodes();
 
@@ -56,7 +57,6 @@ class RegexMatcher {
   
   void AddKleeneStar();
   
-  std::string InfixToPostfix(std::string &infix_regex);
 };
 
 }

--- a/test/testmain.cpp
+++ b/test/testmain.cpp
@@ -101,6 +101,7 @@ TEST_CASE("flex parser") {
   REQUIRE(token.type == Tokentype::Number);
   REQUIRE(token.line == 1);
   REQUIRE(token.lexeme == test_string);
+  delete lexer;
 }
 
 TEST_CASE("flex parser_2") {
@@ -124,4 +125,5 @@ TEST_CASE("flex parser_2") {
     REQUIRE(token.line == std::get<1>(test_tuple));
     REQUIRE(token.type == std::get<2>(test_tuple));
   }
+  delete lexer;
 }

--- a/test/testmain.cpp
+++ b/test/testmain.cpp
@@ -8,28 +8,28 @@
 #include "regex.h"
 
 TEST_CASE("infix to postfix") {
-  std::string regex_1 = "a.b|c.d";
-  REQUIRE(regex::RegexMatcher(regex_1).postfix_regex_ == "ab.cd.|");
-  std::string regex_2 = "a.(b|c).d";
-  REQUIRE(regex::RegexMatcher(regex_2).postfix_regex_ == "abc|.d.");
-  std::string regex_3 = "a.b.c.d";
-  REQUIRE(regex::RegexMatcher(regex_3).postfix_regex_  == "ab.c.d.");
+  std::string regex_1 = "ab|cd";
+  REQUIRE(regex::RegexMatcher(regex_1).postfix_regex() == "ab.cd.|");
+  std::string regex_2 = "a(b|c)d";
+  REQUIRE(regex::RegexMatcher(regex_2).postfix_regex() == "abc|.d.");
+  std::string regex_3 = "abcd";
+  REQUIRE(regex::RegexMatcher(regex_3).postfix_regex()  == "ab.c.d.");
   std::string regex_4 = "a";
-  REQUIRE(regex::RegexMatcher(regex_4).postfix_regex_ == "a");
+  REQUIRE(regex::RegexMatcher(regex_4).postfix_regex() == "a");
   std::string regex_5 = "a*";
-  REQUIRE(regex::RegexMatcher(regex_5).postfix_regex_ == "a*");
-  std::string regex_6 = "a*.b";
-  REQUIRE(regex::RegexMatcher(regex_6).postfix_regex_ == "a*b.");
-  std::string regex_7 = "b.z.a*.d.(a.b)*";
-  REQUIRE(regex::RegexMatcher(regex_7).postfix_regex_ == "bz.a*.d.ab.*.");
-  std::string regex_8 = "(a.b|c*.d)*";
-  REQUIRE(regex::RegexMatcher(regex_8).postfix_regex_ == "ab.c*d.|*");
+  REQUIRE(regex::RegexMatcher(regex_5).postfix_regex() == "a*");
+  std::string regex_6 = "a*b";
+  REQUIRE(regex::RegexMatcher(regex_6).postfix_regex() == "a*b.");
+  std::string regex_7 = "bza*d(ab)*";
+  REQUIRE(regex::RegexMatcher(regex_7).postfix_regex() == "bz.a*.d.ab.*.");
+  std::string regex_8 = "(ab|c*d)*";
+  REQUIRE(regex::RegexMatcher(regex_8).postfix_regex() == "ab.c*d.|*");
   std::string regex_9 = "(1|2|3|4)*";
-  REQUIRE(regex::RegexMatcher(regex_9).postfix_regex_ == "12|3|4|*");
+  REQUIRE(regex::RegexMatcher(regex_9).postfix_regex() == "12|3|4|*");
 }
 
 TEST_CASE("regex matching_1") {
-  std::string regex = "(a.b|c*.d)*";
+  std::string regex = "(ab|c*d)*";
   regex::RegexMatcher compiled_regex(regex);
   std::vector<std::string> test_correct({
       "ab",
@@ -62,14 +62,14 @@ TEST_CASE("regex matching_1") {
 
 TEST_CASE("regex matching_2") {
   std::string regex =
-      "(1|2|3|4|5|6|7|8|9).(0|1|2|3|4|5|6|7|8|9)*.,.(0|1|2|3|4|5|6|7|8|9)";
+      "(1|2|3|4|5|6|7|8|9)(0|1|2|3|4|5|6|7|8|9)*.(0|1|2|3|4|5|6|7|8|9)";
   regex::RegexMatcher compiled_regex(regex);
   std::vector<std::string> test_correct({
-      "12334123339990000,1",
-      "121212,9",
-      "1,0",
-      "9,0",
-      "129349404,6",
+      "12334123339990000.1",
+      "121212.9",
+      "1.0",
+      "9.0",
+      "129349404.6",
   });
   for (auto test_string : test_correct) {
     REQUIRE(compiled_regex.Matches(test_string) == true);
@@ -77,16 +77,135 @@ TEST_CASE("regex matching_2") {
 
   std::vector<std::string> test_incorrect({
       "1233412333999102",
-      "1234,12",
-      "0,01212",
-      "121212,6666",
-      "121212,",
-      "0,123",
+      "1234.12",
+      "0.01212",
+      "121212.6666",
+      "121212.",
+      "0.123",
       "899",
   });
   for (auto test_string : test_incorrect) {
     REQUIRE(compiled_regex.Matches(test_string) == false);
   }
+}
+
+TEST_CASE("identifier regex") {
+  std::string letter = "(a";
+  for (char c = 'b'; c <= 'z'; c++) {
+    letter.push_back('|');
+    letter.push_back(c);
+  }
+  for (char c = 'A'; c <= 'Z'; c++) {
+    letter.push_back('|');
+    letter.push_back(c);
+  }
+  letter += "|_)";
+
+  std::string digits = "(0|1|2|3|4|5|6|7|8|9)";
+
+  std::string identifier_regex = letter + "(" + letter + "|" + digits + ")*";
+  regex::RegexMatcher compiled_regex(identifier_regex);
+  std::vector<std::string> test_correct({
+      "identifier",
+      "_Identifier",
+      "_Identifi3r",
+      "MyCreative_Variable_Name_9098",
+      "iden_ti_fi_er__1212",
+  });
+  for (auto test_string : test_correct) {
+    REQUIRE(compiled_regex.Matches(test_string) == true);
+  }
+
+  std::vector<std::string> test_incorrect({
+      "my_variable?",
+      "12why",
+      "0",
+      "my_var.6666",
+      "my_var_,",
+      "not_an identifier",
+      "asasasas__asdasd^",
+  });
+  for (auto test_string : test_incorrect) {
+    REQUIRE(compiled_regex.Matches(test_string) == false);
+  }
+}
+
+TEST_CASE("escaping characters") {
+  std::string digits = "(0|1|2|3|4|5|6|7|8|9)";
+  std::string regex_1 = digits + "*\\*" + digits + "*";
+  regex::RegexMatcher r1(regex_1);
+  std::vector<std::string> test_correct({
+      "11212*1212",
+      "*",
+      "1*",
+      "1212*098",
+  });
+  for (auto test_string : test_correct)
+    REQUIRE(r1.Matches(test_string) == true);
+
+  std::vector<std::string> test_incorrect({
+      "1212**",
+      "121212",
+      "9999***",
+      "****",
+  });
+  for (auto test_string : test_incorrect)
+    REQUIRE(r1.Matches(test_string) == false);
+
+
+  std::string regex_2 = "(\\(|\\))*";
+  regex::RegexMatcher r2(regex_2);
+  test_correct = std::vector<std::string>({
+      "(((())))",
+      "()()()))",
+      "(((((",
+      "))",
+  });
+  for (auto test_string : test_correct)
+    REQUIRE(r2.Matches(test_string) == true);
+
+  test_incorrect = std::vector<std::string>({
+      "(a",
+      "(( ",
+      "as",
+      "())).",
+  });
+  for (auto test_string : test_incorrect)
+    REQUIRE(r2.Matches(test_string) == false);
+}
+
+TEST_CASE("keyword matching") {
+  std::string keywords = "(class|static|void|if|else|for|return|break|continue|int|real)";
+
+  regex::RegexMatcher compiled_regex(keywords);
+  std::vector<std::string> test_correct({
+      "static",
+      "void",
+      "else",
+      "for",
+      "return",
+      "break",
+      "continue",
+      "int",
+      "real",
+      "class",
+      "if",
+  });
+  for (auto test_string : test_correct) 
+    REQUIRE(compiled_regex.Matches(test_string) == true);
+
+
+  std::vector<std::string> test_incorrect({
+      "float",
+      "def",
+      "var",
+      "foo",
+      "lol",
+      "uint",
+      "char",
+  });
+  for (auto test_string : test_incorrect)
+    REQUIRE(compiled_regex.Matches(test_string) == false);
 }
 
 

--- a/test/testmain.cpp
+++ b/test/testmain.cpp
@@ -102,3 +102,26 @@ TEST_CASE("flex parser") {
   REQUIRE(token.line == 1);
   REQUIRE(token.lexeme == test_string);
 }
+
+TEST_CASE("flex parser_2") {
+  SymbolTable sym;
+  std::string test_string = "a = 5;";
+  std::stringstream sf(test_string);
+
+  std::vector<std::tuple<std::string, int, Tokentype>> expected_output = {
+    std::make_tuple("a", 1, Tokentype::Identifier),
+    std::make_tuple("=", 1, Tokentype::OpAssign),
+    std::make_tuple("5", 1, Tokentype::Number),
+    std::make_tuple(";", 1, Tokentype::ptSemicolon)
+  };
+
+  Lexer* lexer;
+  lexer = new FLexer(sf, sym);
+  Token token;
+  for (auto test_tuple : expected_output) {
+    lexer->get_next(token);
+    REQUIRE(token.lexeme == std::get<0>(test_tuple));
+    REQUIRE(token.line == std::get<1>(test_tuple));
+    REQUIRE(token.type == std::get<2>(test_tuple));
+  }
+}


### PR DESCRIPTION
this adds support for escaped input characters (so now you can add \* and won't be interpreted as star operator), and adds concatenation between symbols so it's not necessary to do it manually. The tests show several examples.

still need to:
- add support for '+' and '?'
- combine multiple regex to process a bunch of text